### PR TITLE
remove python 3.9 CI runs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,14 +41,14 @@ jobs:
           noxenv: tests-3.10
           python: '3.10'
 
-        - name: Tests, Python 3.9, Windows
-          os: windows-latest
-          python: 3.9
-          noxenv: tests-3.9
+        - name: Tests, Python 3.10, Linux
+          os: ubuntu-latest
+          noxenv: tests-3.10
+          python: '3.10'
 
-        - name: Import XRTpy, Python 3.9, Windows
-          os: windows-latest
-          python: 3.9
+        - name: Import XRTpy, Python 3.10, Linux
+          os: ubuntu-latest
+          python: 3.10
           noxenv: import_package
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ dmypy.json
 version.py
 .idea
 .vscode
+.history
 .\#*
 
 #ignore mac files


### PR DESCRIPTION
Might fix the PR CI.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update CI configuration to remove Python 3.9 runs and replace them with Python 3.10 runs on Linux.

CI:
- Remove Python 3.9 CI runs and replace them with Python 3.10 runs on Linux.

<!-- Generated by sourcery-ai[bot]: end summary -->